### PR TITLE
🔧 update hyperbridge node to v0.3.6

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,4 +1,4 @@
 ---
 system_username: hyperbridge
 hyperbridge_username: hyperbridge-user
-version: 0.3.5
+version: 0.3.6


### PR DESCRIPTION
Release only adds RPC methods for the frontend